### PR TITLE
LeapSecondInfo: use dataclass instead of NamedTuple

### DIFF
--- a/leapseconddata/__init__.py
+++ b/leapseconddata/__init__.py
@@ -38,8 +38,12 @@ NTP_EPOCH = datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc)
 
 @dataclass(frozen=True)
 class LeapSecondInfo:
+    """Information about a particular leap second"""
+
     start: datetime.datetime
-    """The UTC timestamp just after the insertion of the leap second."""
+    """The UTC timestamp just after the insertion of the leap second.
+
+    The leap second is actually the 61th second of the previous minute (xx:xx:60)"""
 
     tai_offset: datetime.timedelta
     """The new TAI-UTC offset.  Positive numbers indicate that TAI is ahead of UTC"""

--- a/leapseconddata/__main__.py
+++ b/leapseconddata/__main__.py
@@ -20,8 +20,8 @@ def main() -> None:
     lsd = LeapSecondData.from_standard_source()
     print(f"Last updated: {lsd.last_updated:%Y-%m-%d}")
     print(f"Valid until:  {lsd.valid_until:%Y-%m-%d}")
-    for when, offset in lsd.leap_seconds[-10:]:
-        print(f"{when:%Y-%m-%d}: {offset.total_seconds()}")
+    for leap_second in lsd.leap_seconds[-10:]:
+        print(f"{leap_second.start:%Y-%m-%d}: {leap_second.tai_offset.total_seconds()}")
     when = datetime.datetime(2011, 1, 1, tzinfo=datetime.timezone.utc)
     print(f"TAI-UTC on {when:%Y-%m-%d} was {lsd.tai_offset(when).total_seconds()}")
 


### PR DESCRIPTION
The documentation workaround for the dataclass was worse than the benefit from being able to tuple-unpack it.